### PR TITLE
Fix adding items to a complete empty dashboard

### DIFF
--- a/lib/src/controller/dashboard_controller.dart
+++ b/lib/src/controller/dashboard_controller.dart
@@ -383,6 +383,17 @@ class _DashboardLayoutController<T extends DashboardItem> with ChangeNotifier {
   }
 
   void addAll(List<DashboardItem> items, {bool mountToTop = true}) {
+    if (_isAttached == false) {
+      attach(
+        axis: Axis.vertical,
+        itemController: itemController,
+        slotCount: slotCount,
+        slideToTop: slideToTop,
+        shrinkToPlace: shrinkToPlace,
+        animateEverytime: animateEverytime,
+        shrinkOnMove: shrinkOnMove,
+      );
+    }
     for (var item in items) {
       _layouts![item.identifier] = _ItemCurrentLayout(item.layoutData);
 

--- a/lib/src/controller/dashboard_controller.dart
+++ b/lib/src/controller/dashboard_controller.dart
@@ -216,7 +216,17 @@ class DashboardItemController<T extends DashboardItem> with ChangeNotifier {
 ///
 class _DashboardLayoutController<T extends DashboardItem> with ChangeNotifier {
   ///
-  _DashboardLayoutController();
+  _DashboardLayoutController({
+    required this.itemController,
+    required this.slotCount,
+    required this.slideToTop,
+    required this.shrinkToPlace,
+    required this.animateEverytime,
+    required this.shrinkOnMove,
+    required Axis axis,
+  }) {
+    _axis = axis;
+  }
 
   ///
   late DashboardItemController<T> itemController;
@@ -341,6 +351,17 @@ class _DashboardLayoutController<T extends DashboardItem> with ChangeNotifier {
   }
 
   void add(DashboardItem item, [bool mountToTop = true]) {
+    if (_isAttached == false) {
+      attach(
+        axis: Axis.vertical,
+        itemController: itemController,
+        slotCount: slotCount,
+        slideToTop: slideToTop,
+        shrinkToPlace: shrinkToPlace,
+        animateEverytime: animateEverytime,
+        shrinkOnMove: shrinkOnMove,
+      );
+    }
     _layouts![item.identifier] = _ItemCurrentLayout(item.layoutData);
     this.mountToTop(
         item.identifier,
@@ -839,10 +860,10 @@ class _DashboardLayoutController<T extends DashboardItem> with ChangeNotifier {
     this.slotCount = slotCount;
     this.animateEverytime = animateEverytime;
     _axis = axis;
-    _isAttached = true;
 
     _layouts = itemController._items.map((key, value) =>
         MapEntry(value.identifier, _ItemCurrentLayout(value.layoutData)));
+    _isAttached = true;
     mountItems();
     _rebuild = true;
   }

--- a/lib/src/widgets/dashboard.dart
+++ b/lib/src/widgets/dashboard.dart
@@ -199,7 +199,14 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
   ///
   @override
   void initState() {
-    _layoutController = _DashboardLayoutController<T>();
+    _layoutController = _DashboardLayoutController<T>(
+        itemController: widget.dashboardItemController,
+        animateEverytime: widget.animateEverytime,
+        axis: Axis.vertical,
+        shrinkOnMove: widget.editModeSettings.shrinkOnMove,
+        shrinkToPlace: widget.shrinkToPlace,
+        slideToTop: widget.slideToTop,
+        slotCount: widget.slotCount);
     _layoutController.addListener(() {
       setState(() {});
     });
@@ -399,7 +406,9 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
         }
       }
       if (widget.dashboardItemController._items.isEmpty) {
-        return widget.dashboardItemController.isEditing ? dashboardWidget(constrains) : widget.emptyPlaceholder ?? const SizedBox();
+        return widget.dashboardItemController.isEditing
+            ? dashboardWidget(constrains)
+            : widget.emptyPlaceholder ?? const SizedBox();
       }
 
       return dashboardWidget(constrains);
@@ -408,14 +417,12 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
 
   Widget dashboardWidget(BoxConstraints constrains) {
     return Scrollable(
-        physics: scrollable
-            ? widget.physics
-            : const NeverScrollableScrollPhysics(),
+        physics:
+            scrollable ? widget.physics : const NeverScrollableScrollPhysics(),
         key: _scrollableKey,
         controller: widget.scrollController,
         semanticChildCount: widget.dashboardItemController._items.length,
-        dragStartBehavior:
-        widget.dragStartBehavior ?? DragStartBehavior.start,
+        dragStartBehavior: widget.dragStartBehavior ?? DragStartBehavior.start,
         scrollBehavior: widget.scrollBehavior,
         viewportBuilder: (c, o) {
           if (!_reloading) _setNewOffset(o, constrains);


### PR DESCRIPTION
I got a null reference exception while testing the package with a storage delegate returning an empty list of items, the reason was that the `_layouts` map was not initialized correctly. 
To fix this I pass all the parameters during the controller creation and call the `attach` (if `_isAttached` is false) method inside the `add` and `addAll` calls.