### PR TITLE
- Infinite dashboard scroll/resize fix

### DIFF
--- a/lib/src/widgets/dashboard_stack.dart
+++ b/lib/src/widgets/dashboard_stack.dart
@@ -539,9 +539,9 @@ class _DashboardStackState<T extends DashboardItem>
       _moveStartOffset = null;
       _holdDirections = null;
       _startScrollPixels = null;
-      speed = 0;
       widget.dashboardController.saveEditSession();
     });
+    speed = 0;
     widget.onScrollStateChange(true);
   }
 }


### PR DESCRIPTION
When the user grabs the left or right handle to resize the widget and moves the mouse downward, the dashboard enters into an infinite scrolling (resizing) on the y-axis. This commit addresses this issue by ensuring that when the mouse is released, the dashboard jumps back up to its original position.