### PR TITLE
Fix: Ensure AnimationController is created after mixin initState

### DIFF
--- a/lib/src/widgets/animated_background_painter.dart
+++ b/lib/src/widgets/animated_background_painter.dart
@@ -1,3 +1,5 @@
+// lib\src\widgets\animated_background_painter.dart
+
 part of '../dashboard_base.dart';
 
 class _AnimatedBackgroundPainter extends StatefulWidget {
@@ -30,11 +32,12 @@ class _AnimatedBackgroundPainterState extends State<_AnimatedBackgroundPainter>
 
   @override
   void initState() {
+    super.initState();  // <- MUST come first
     offset = widget.offset.pixels;
     _animationController = AnimationController(
         vsync: this, duration: widget.editModeSettings.duration);
-    super.initState();
   }
+
 
   @override
   void dispose() {


### PR DESCRIPTION
### Problem
Creating the `AnimationController` before `super.initState()` causes the `SingleTickerProviderStateMixin` to miss the ticker registration. This leads to the following error at runtime:

`_Ticker was disposed with an active Ticker.`

This crash occurs when toggling edit mode or navigating away from the dashboard with animated slot backgrounds enabled.

### Fix
Moved the call to `super.initState()` to the **top of the `initState()` method** in `_AnimatedBackgroundPainterState`:

```
@override
void initState() {
  super.initState();  // <- now runs before controller is created
  offset = widget.offset.pixels;
  _animationController = AnimationController(
    vsync: this,
    duration: widget.editModeSettings.duration,
  );
}
```
### Result
* The ticker is properly tracked and disposed
* Eliminates the runtime crash when edit mode is toggled
* Restores expected drag-and-drop behavior

Safe internal fix — no API changes.