### PR TITLE
Add: notifyItemsChangedExternally for external layout rehydration

### DIFF
--- a/lib/src/controller/dashboard_controller.dart
+++ b/lib/src/controller/dashboard_controller.dart
@@ -157,6 +157,15 @@ class DashboardItemController<T extends DashboardItem> with ChangeNotifier {
 
   Duration? _timeout;
 
+
+  void notifyItemsChangedExternally(List<T> newItems) {
+    _items = newItems.asMap().map((key, value) => MapEntry(value.identifier, value));
+    _layoutController?.mountItems(); // ← optional: only if you want to refresh visual layout
+    _asyncSnap?.value = AsyncSnapshot.withData(ConnectionState.done, newItems);
+    notifyListeners();
+  }
+
+
   FutureOr<void> _loadItems(int slotCount) {
     var ftr = itemStorageDelegate!._getAllItems(slotCount);
     if (ftr is Future<List<T>>) {

--- a/lib/src/widgets/animated_background_painter.dart
+++ b/lib/src/widgets/animated_background_painter.dart
@@ -1,3 +1,5 @@
+// lib\src\widgets\animated_background_painter.dart
+
 part of '../dashboard_base.dart';
 
 class _AnimatedBackgroundPainter extends StatefulWidget {
@@ -30,11 +32,12 @@ class _AnimatedBackgroundPainterState extends State<_AnimatedBackgroundPainter>
 
   @override
   void initState() {
+    super.initState();  // <- MUST come first
     offset = widget.offset.pixels;
     _animationController = AnimationController(
         vsync: this, duration: widget.editModeSettings.duration);
-    super.initState();
   }
+
 
   @override
   void dispose() {


### PR DESCRIPTION
### Feature
This PR introduces a new method to `DashboardItemController` called `notifyItemsChangedExternally`, which allows developers to push externally loaded dashboard items into the controller **after initialization**.

```
void notifyItemsChangedExternally(List<T> newItems) {
  _items = newItems.asMap().map((key, value) => MapEntry(value.identifier, value));
  _layoutController?.mountItems(); // Reindex and remount layout
  _asyncSnap?.value = AsyncSnapshot.withData(ConnectionState.done, newItems);
  notifyListeners();
}
```

### Use Case
Right now, the dashboard package provides no first-class way to inject layout state dynamically (e.g., after loading from local storage or a remote API). This method solves that by:
* Replacing the internal items list
* Re-mounting and reindexing the layout if attached
* Updating listeners and snapshots

This method enables use cases like:
* Loading saved dashboards from SharedPreferences
* Restoring layouts after login
* Switching between user-defined presets

### Safe and Non-Breaking
* This is a completely optional method
* No impact to default behavior or existing API contracts
* Preserves layout reactivity and async loading logic