### PR TITLE
isEditing parameter for DashboardItemController ctor and a child Widget parameter for Dashboard

### DIFF
--- a/lib/src/controller/dashboard_controller.dart
+++ b/lib/src/controller/dashboard_controller.dart
@@ -23,9 +23,11 @@ class DashboardItemController<T extends DashboardItem> with ChangeNotifier {
   /// Changes cannot be handled.
   DashboardItemController({
     required List<T> items,
+    bool isEditing = false,
   })  : _items = items.asMap().map(
               (key, value) => MapEntry(value.identifier, value),
             ),
+        _initialIsEditing = isEditing,
         itemStorageDelegate = null;
 
   /// You can create [DashboardItemController] with an [itemStorageDelegate].
@@ -34,14 +36,20 @@ class DashboardItemController<T extends DashboardItem> with ChangeNotifier {
   ///
   /// If the delegate is waiting for a Future to load the items, this will throw
   /// error at the end of the [timout].
-  DashboardItemController.withDelegate(
-      {Duration? timeout, required this.itemStorageDelegate})
-      : _timeout = timeout ?? const Duration(seconds: 10);
+  DashboardItemController.withDelegate({
+    Duration? timeout,
+    required this.itemStorageDelegate,
+    bool isEditing = false,
+  })  : _timeout = timeout ?? const Duration(seconds: 10),
+        _initialIsEditing = isEditing;
 
   /// To define [itemStorageDelegate] use [DashboardItemController.withDelegate]
   ///
   /// For more see [DashboardItemStorageDelegate] documentation.
   final DashboardItemStorageDelegate<T>? itemStorageDelegate;
+
+  /// Initial editing state for the controller.
+  final bool _initialIsEditing;
 
   /// Users can only edit the layout when [isEditing] is true.
   /// The [isEditing] does not have to be true to add or delete items.
@@ -206,6 +214,7 @@ class DashboardItemController<T extends DashboardItem> with ChangeNotifier {
 
   void _attach(_DashboardLayoutController layoutController) {
     _layoutController = layoutController;
+    _layoutController!.isEditing = _initialIsEditing;
   }
 }
 

--- a/lib/src/widgets/dashboard.dart
+++ b/lib/src/widgets/dashboard.dart
@@ -51,8 +51,7 @@ class Dashboard<T extends DashboardItem> extends StatefulWidget {
       this.itemStyle = const ItemStyle(),
       this.scrollToAdded = true,
       this.child})
-      : assert((slotHeight == null && slotAspectRatio == null) ||
-            !(slotHeight != null && slotAspectRatio != null)),
+      : assert((slotHeight == null && slotAspectRatio == null) || !(slotHeight != null && slotAspectRatio != null)),
         editModeSettings = editModeSettings ?? EditModeSettings(),
         super(key: key);
 
@@ -203,8 +202,7 @@ class Dashboard<T extends DashboardItem> extends StatefulWidget {
   State<Dashboard<T>> createState() => _DashboardState<T>();
 }
 
-class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
-    with TickerProviderStateMixin {
+class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>> with TickerProviderStateMixin {
   ///
   @override
   void initState() {
@@ -233,8 +231,7 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
 
   AsyncSnapshot? get _snap => widget.dashboardItemController._asyncSnap?.value;
 
-  bool get _withDelegate =>
-      widget.dashboardItemController.itemStorageDelegate != null;
+  bool get _withDelegate => widget.dashboardItemController.itemStorageDelegate != null;
 
   ///
   late _DashboardLayoutController<T> _layoutController;
@@ -304,21 +301,16 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
     if (widget.slotHeight != null) {
       h = widget.slotHeight!;
     } else if (widget.slotAspectRatio != null) {
-      h = _layoutController._viewportDelegate.resolvedConstrains.maxWidth /
-          widget.slotCount /
-          widget.slotAspectRatio!;
+      h = _layoutController._viewportDelegate.resolvedConstrains.maxWidth / widget.slotCount / widget.slotAspectRatio!;
     } else {
-      h = _layoutController._viewportDelegate.resolvedConstrains.maxWidth /
-          widget.slotCount;
+      h = _layoutController._viewportDelegate.resolvedConstrains.maxWidth / widget.slotCount;
     }
 
-    _layoutController._setSizes(
-        _layoutController._viewportDelegate.resolvedConstrains, h);
+    _layoutController._setSizes(_layoutController._viewportDelegate.resolvedConstrains, h);
 
     _offset = o;
 
-    offset.applyViewportDimension(
-        _layoutController._viewportDelegate.constraints.maxHeight);
+    offset.applyViewportDimension(_layoutController._viewportDelegate.constraints.maxHeight);
 
     var maxIndex = (_layoutController._endsTree.lastKey() ?? 0);
 
@@ -341,11 +333,9 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
   late double _maxExtend;
 
   ///
-  final GlobalKey<_DashboardStackState<T>> _stateKey =
-      GlobalKey<_DashboardStackState<T>>();
+  final GlobalKey<_DashboardStackState<T>> _stateKey = GlobalKey<_DashboardStackState<T>>();
 
-  final GlobalKey<ScrollableState> _scrollableKey =
-      GlobalKey<ScrollableState>();
+  final GlobalKey<ScrollableState> _scrollableKey = GlobalKey<ScrollableState>();
 
   bool scrollable = true;
 
@@ -359,8 +349,7 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
         (!_reloading || differentReload) &&
         _layoutController.slotCount != widget.slotCount &&
         _withDelegate &&
-        widget
-            .dashboardItemController.itemStorageDelegate!.layoutsBySlotCount) {
+        widget.dashboardItemController.itemStorageDelegate!.layoutsBySlotCount) {
       _reloading = true;
       _reloadFor = widget.slotCount;
       widget.dashboardItemController._items.clear();
@@ -407,11 +396,8 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
       if (_withDelegate) {
         if (_snap!.connectionState == ConnectionState.none) {
           _building = false;
-          return widget.errorPlaceholder
-                  ?.call(_snap!.error!, _snap!.stackTrace!) ??
-              const SizedBox();
-        } else if (_snap!.connectionState == ConnectionState.waiting ||
-            _reloading) {
+          return widget.errorPlaceholder?.call(_snap!.error!, _snap!.stackTrace!) ?? const SizedBox();
+        } else if (_snap!.connectionState == ConnectionState.waiting || _reloading) {
           _building = false;
 
           return widget.loadingPlaceholder ??
@@ -427,8 +413,7 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
 
   Widget dashboardWidget(BoxConstraints constrains) {
     return Scrollable(
-        physics:
-            scrollable ? widget.physics : const NeverScrollableScrollPhysics(),
+        physics: scrollable ? widget.physics : const NeverScrollableScrollPhysics(),
         key: _scrollableKey,
         controller: widget.scrollController,
         semanticChildCount: widget.dashboardItemController._items.length,
@@ -465,10 +450,7 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
 }
 
 class _ItemCurrentPositionTween extends Tween<_ItemCurrentPosition> {
-  _ItemCurrentPositionTween(
-      {required _ItemCurrentPosition begin,
-      required _ItemCurrentPosition end,
-      required this.onlyDimensions})
+  _ItemCurrentPositionTween({required _ItemCurrentPosition begin, required _ItemCurrentPosition end, required this.onlyDimensions})
       : super(begin: begin, end: end);
 
   bool onlyDimensions;

--- a/lib/src/widgets/dashboard.dart
+++ b/lib/src/widgets/dashboard.dart
@@ -49,7 +49,8 @@ class Dashboard<T extends DashboardItem> extends StatefulWidget {
       this.absorbPointer = true,
       this.animateEverytime = true,
       this.itemStyle = const ItemStyle(),
-      this.scrollToAdded = true})
+      this.scrollToAdded = true,
+      this.child})
       : assert((slotHeight == null && slotAspectRatio == null) ||
             !(slotHeight != null && slotAspectRatio != null)),
         editModeSettings = editModeSettings ?? EditModeSettings(),
@@ -194,6 +195,9 @@ class Dashboard<T extends DashboardItem> extends StatefulWidget {
   ///
   /// Look [Material] documentation for more.
   final ItemStyle itemStyle;
+
+  /// Optional child widget to be added to the Stack.
+  final Widget? child;
 
   @override
   State<Dashboard<T>> createState() => _DashboardState<T>();
@@ -454,7 +458,8 @@ class _DashboardState<T extends DashboardItem> extends State<Dashboard<T>>
               key: _stateKey,
               itemBuilder: widget.itemBuilder,
               dashboardController: _layoutController,
-              offset: offset);
+              offset: offset,
+              child: widget.child);
         });
   }
 }

--- a/lib/src/widgets/dashboard_stack.dart
+++ b/lib/src/widgets/dashboard_stack.dart
@@ -12,7 +12,8 @@ class _DashboardStack<T extends DashboardItem> extends StatefulWidget {
       required this.onScrollStateChange,
       required this.shouldCalculateNewDimensions,
       required this.itemStyle,
-      required this.emptyPlaceholder})
+      required this.emptyPlaceholder,
+      this.child})
       : super(key: key);
 
   final Widget? emptyPlaceholder;
@@ -29,6 +30,8 @@ class _DashboardStack<T extends DashboardItem> extends StatefulWidget {
   final ItemStyle itemStyle;
 
   final void Function() shouldCalculateNewDimensions;
+
+  final Widget? child;
 
   @override
   State<_DashboardStack<T>> createState() => _DashboardStackState<T>();
@@ -223,6 +226,7 @@ class _DashboardStackState<T extends DashboardItem>
     Widget result = Stack(
       clipBehavior: Clip.hardEdge,
       children: [
+        if (widget.child != null) widget.child!,
         if (widget.editModeSettings.paintBackgroundLines &&
             widget.dashboardController.isEditing)
           Positioned(
@@ -259,7 +263,7 @@ class _DashboardStackState<T extends DashboardItem>
             : [
                 buildPositioned(_widgetsMap[
                     widget.dashboardController.editSession?.editing.id]!)
-              ])
+              ]),
       ],
     );
 

--- a/lib/src/widgets/dashboard_stack.dart
+++ b/lib/src/widgets/dashboard_stack.dart
@@ -37,13 +37,11 @@ class _DashboardStack<T extends DashboardItem> extends StatefulWidget {
   State<_DashboardStack<T>> createState() => _DashboardStackState<T>();
 }
 
-class _DashboardStackState<T extends DashboardItem>
-    extends State<_DashboardStack<T>> {
+class _DashboardStackState<T extends DashboardItem> extends State<_DashboardStack<T>> {
   ///
   ViewportOffset get viewportOffset => widget.offset;
 
-  _ViewportDelegate get viewportDelegate =>
-      widget.dashboardController._viewportDelegate;
+  _ViewportDelegate get viewportDelegate => widget.dashboardController._viewportDelegate;
 
   ///
   double get pixels => viewportOffset.pixels;
@@ -94,10 +92,8 @@ class _DashboardStackState<T extends DashboardItem>
     return _DashboardItemWidget(
       style: widget.itemStyle,
       key: _keys[list[2]]!,
-      itemGlobalPosition: (list[0] as _ItemCurrentLayout)._currentPosition(
-          viewportDelegate: viewportDelegate,
-          slotEdge: slotEdge,
-          verticalSlotEdge: verticalSlotEdge),
+      itemGlobalPosition:
+          (list[0] as _ItemCurrentLayout)._currentPosition(viewportDelegate: viewportDelegate, slotEdge: slotEdge, verticalSlotEdge: verticalSlotEdge),
       itemCurrentLayout: list[0],
       id: list[2],
       editModeSettings: widget.editModeSettings,
@@ -126,8 +122,7 @@ class _DashboardStackState<T extends DashboardItem>
             shape: widget.itemStyle.shape,
             color: widget.itemStyle.color,
             clipBehavior: widget.itemStyle.clipBehavior ?? Clip.none,
-            animationDuration:
-                widget.itemStyle.animationDuration ?? kThemeChangeDuration,
+            animationDuration: widget.itemStyle.animationDuration ?? kThemeChangeDuration,
             child: widget.itemBuilder(i),
             //shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
           )),
@@ -155,8 +150,7 @@ class _DashboardStackState<T extends DashboardItem>
 
     var endPixels = viewportOffset.pixels + height + widget.cacheExtend;
     var endY = (endPixels / verticalSlotEdge).ceil();
-    var endIndex = widget.dashboardController
-        .getIndex([widget.dashboardController.slotCount - 1, endY]);
+    var endIndex = widget.dashboardController.getIndex([widget.dashboardController.slotCount - 1, endY]);
 
     var needs = <String>[];
     var key = startIndex;
@@ -227,43 +221,23 @@ class _DashboardStackState<T extends DashboardItem>
       clipBehavior: Clip.hardEdge,
       children: [
         if (widget.child != null) widget.child!,
-        if (widget.editModeSettings.paintBackgroundLines &&
-            widget.dashboardController.isEditing)
+        if (widget.editModeSettings.paintBackgroundLines && widget.dashboardController.isEditing)
           Positioned(
             top: viewportDelegate.padding.top,
             left: viewportDelegate.padding.left,
-            width: viewportDelegate.constraints.maxWidth -
-                viewportDelegate.padding.vertical,
-            height: viewportDelegate.constraints.maxHeight -
-                viewportDelegate.padding.horizontal,
+            width: viewportDelegate.constraints.maxWidth - viewportDelegate.padding.vertical,
+            height: viewportDelegate.constraints.maxHeight - viewportDelegate.padding.horizontal,
             child: Builder(builder: (context) {
               return _AnimatedBackgroundPainter(
-                  layoutController: widget.dashboardController,
-                  editModeSettings: widget.editModeSettings,
-                  offset: viewportOffset);
+                  layoutController: widget.dashboardController, editModeSettings: widget.editModeSettings, offset: viewportOffset);
             }),
           ),
-        ..._widgetsMap.entries
-            .where((element) =>
-                element.value[2] !=
-                widget.dashboardController.editSession?.editing.id)
-            .map((e) {
+        ..._widgetsMap.entries.where((element) => element.value[2] != widget.dashboardController.editSession?.editing.id).map((e) {
           return buildPositioned(e.value);
         }).toList(),
-        if (widget.dashboardController.itemController._items.isEmpty &&
-            !widget.dashboardController._isEditing)
-          Positioned(
-              bottom: 0,
-              left: 0,
-              right: 0,
-              top: 0,
-              child: widget.emptyPlaceholder ?? Container()),
-        ...?(widget.dashboardController.editSession == null
-            ? null
-            : [
-                buildPositioned(_widgetsMap[
-                    widget.dashboardController.editSession?.editing.id]!)
-              ]),
+        if (widget.dashboardController.itemController._items.isEmpty && !widget.dashboardController._isEditing)
+          Positioned(bottom: 0, left: 0, right: 0, top: 0, child: widget.emptyPlaceholder ?? Container()),
+        ...?(widget.dashboardController.editSession == null ? null : [buildPositioned(_widgetsMap[widget.dashboardController.editSession?.editing.id]!)]),
       ],
     );
 
@@ -353,50 +327,37 @@ class _DashboardStackState<T extends DashboardItem>
   Offset holdOffset = Offset.zero;
 
   void _onMoveStart(Offset local) {
-    var holdGlobal = Offset(local.dx - viewportDelegate.padding.left,
-        local.dy - viewportDelegate.padding.top);
+    var holdGlobal = Offset(local.dx - viewportDelegate.padding.left, local.dy - viewportDelegate.padding.top);
 
     var x = (local.dx - viewportDelegate.padding.left) ~/ slotEdge;
-    var y =
-        (local.dy + pixels - viewportDelegate.padding.top) ~/ verticalSlotEdge;
+    var y = (local.dy + pixels - viewportDelegate.padding.top) ~/ verticalSlotEdge;
 
-    var e = widget.dashboardController
-        ._indexesTree[widget.dashboardController.getIndex([x, y])];
+    var e = widget.dashboardController._indexesTree[widget.dashboardController.getIndex([x, y])];
 
     if (e is String) {
       var directions = <AxisDirection>[];
       _editing = widget.dashboardController._layouts![e]!;
-      var current = _editing!._currentPosition(
-          slotEdge: slotEdge,
-          viewportDelegate: viewportDelegate,
-          verticalSlotEdge: verticalSlotEdge);
+      var current = _editing!._currentPosition(slotEdge: slotEdge, viewportDelegate: viewportDelegate, verticalSlotEdge: verticalSlotEdge);
       var itemGlobal = _ItemCurrentPosition(
-          x: current.x - viewportDelegate.padding.left,
-          y: current.y - viewportDelegate.padding.top - pixels,
-          height: current.height,
-          width: current.width);
+          x: current.x - viewportDelegate.padding.left, y: current.y - viewportDelegate.padding.top - pixels, height: current.height, width: current.width);
       if (holdGlobal.dx < itemGlobal.x || holdGlobal.dy < itemGlobal.y) {
         _editing = null;
         setState(() {});
         return;
       }
-      if (itemGlobal.x + widget.editModeSettings.resizeCursorSide >
-          holdGlobal.dx) {
+      if (itemGlobal.x + widget.editModeSettings.resizeCursorSide > holdGlobal.dx) {
         directions.add(AxisDirection.left);
       }
 
-      if ((itemGlobal.y) + widget.editModeSettings.resizeCursorSide >
-          holdGlobal.dy) {
+      if ((itemGlobal.y) + widget.editModeSettings.resizeCursorSide > holdGlobal.dy) {
         directions.add(AxisDirection.up);
       }
 
-      if (itemGlobal.endX - widget.editModeSettings.resizeCursorSide <
-          holdGlobal.dx) {
+      if (itemGlobal.endX - widget.editModeSettings.resizeCursorSide < holdGlobal.dx) {
         directions.add(AxisDirection.right);
       }
 
-      if ((itemGlobal.endY) - widget.editModeSettings.resizeCursorSide <
-          holdGlobal.dy) {
+      if ((itemGlobal.endY) - widget.editModeSettings.resizeCursorSide < holdGlobal.dy) {
         directions.add(AxisDirection.down);
       }
       if (directions.isNotEmpty) {
@@ -411,10 +372,7 @@ class _DashboardStackState<T extends DashboardItem>
       holdOffset = holdGlobal - Offset(itemGlobal.x, itemGlobal.y);
 
       var l = widget.dashboardController._layouts![e];
-      widget.dashboardController.editSession!.editing._originSize = [
-        l!.width,
-        l.height
-      ];
+      widget.dashboardController.editSession!.editing._originSize = [l!.width, l.height];
       setState(() {});
       widget.onScrollStateChange(false);
     } else {
@@ -435,8 +393,7 @@ class _DashboardStackState<T extends DashboardItem>
   Offset? _moveStartOffset;
   double? _startScrollPixels;
 
-  bool isResizing(AxisDirection direction) =>
-      _holdDirections!.contains(direction);
+  bool isResizing(AxisDirection direction) => _holdDirections!.contains(direction);
 
   void _onMoveUpdate(Offset local) {
     if (_editing != null) {
@@ -456,8 +413,7 @@ class _DashboardStackState<T extends DashboardItem>
 
         if (resizeMoveResult.isChanged) {
           setState(() {
-            _moveStartOffset =
-                _moveStartOffset! + resizeMoveResult.startDifference;
+            _moveStartOffset = _moveStartOffset! + resizeMoveResult.startDifference;
             _widgetsMap.remove(_editing!.id);
             for (var r in differences) {
               _widgetsMap.remove(r);
@@ -468,14 +424,10 @@ class _DashboardStackState<T extends DashboardItem>
           });
         }
       } else {
-        var resizeMoveResult = _editing!._transformUpdate(
-            local - _moveStartOffset!,
-            pixels - _startScrollPixels!,
-            holdOffset);
+        var resizeMoveResult = _editing!._transformUpdate(local - _moveStartOffset!, pixels - _startScrollPixels!, holdOffset);
         if (resizeMoveResult != null && resizeMoveResult.isChanged) {
           setState(() {
-            _moveStartOffset =
-                _moveStartOffset! + resizeMoveResult.startDifference;
+            _moveStartOffset = _moveStartOffset! + resizeMoveResult.startDifference;
             _widgetsMap.remove(_editing!.id);
 
             if (_editing!._endIndex > (e)) {
@@ -489,10 +441,7 @@ class _DashboardStackState<T extends DashboardItem>
 
   void _onMoveEnd() {
     _editing?._key = _keys[_editing!.id]!;
-    _editing?._key.currentState
-        ?._setLast(
-            _editing!._transform?.value, _editing!._resizePosition?.value)
-        .then((value) {
+    _editing?._key.currentState?._setLast(_editing!._transform?.value, _editing!._resizePosition?.value).then((value) {
       widget.dashboardController.editSession?.editing._originSize = null;
       _editing?._clearListeners();
       _editing = null;


### PR DESCRIPTION
* Allowing initializing `DashboardItemController` with an `isEditing` value to make it started in an edit mode from the beginning.
* Allowing providing to `Dashboard` a `child` Widget to be laid out as the first element (i.e. most bottom z-order) to function as a background. Useful when wish to have an interactive background/content that is not necessarily the overlay/floating dashboard elements